### PR TITLE
fix: filter empty slots and update storybooks

### DIFF
--- a/packages/kiwi-core/src/Accordion/index.js
+++ b/packages/kiwi-core/src/Accordion/index.js
@@ -56,7 +56,8 @@ const Accordion = {
     }
   },
   render (h) {
-    const cloned = cloneVNodes(this.$slots.default, h)
+    const children = this.$slots.default.filter(e => e.tag)
+    const cloned = cloneVNodes(children, h)
     const clones = cloned.map((vnode, index) => {
       const clone = h(vnode.componentOptions.Ctor, {
         ...vnode.data,

--- a/packages/kiwi-core/src/AvatarGroup/index.js
+++ b/packages/kiwi-core/src/AvatarGroup/index.js
@@ -58,7 +58,7 @@ const AvatarGroup = {
   },
   render (h) {
     // Get the number of slot nodes inside AvatarGroup
-    const children = this.$slots.default
+    const children = this.$slots.default.filter(e => e.tag)
     const count = children.length
     const max = parseInt(this.max, 10)
 

--- a/packages/kiwi-core/src/Breadcrumb/index.js
+++ b/packages/kiwi-core/src/Breadcrumb/index.js
@@ -86,7 +86,7 @@ const BreadcrumbItem = {
   },
   setup (props, context) {
     return () => {
-      const children = context.slots.default()
+      const children = context.slots.default().filter(e => e.tag)
       const clones = cloneVNodes(children, h).map((clone) => {
         if (clone.componentOptions.tag === BreadcrumbLink.name) {
           const { propsData } = clone.componentOptions
@@ -142,7 +142,7 @@ const Breadcrumb = {
   },
   setup (props, context) {
     return () => {
-      const children = context.slots.default()
+      const children = context.slots.default().filter(e => e.tag)
       const clones = cloneVNodes(children, h)
         .map((node, index, array) => {
           const { propsData } = node.componentOptions

--- a/packages/kiwi-core/src/ButtonGroup/index.js
+++ b/packages/kiwi-core/src/ButtonGroup/index.js
@@ -16,7 +16,7 @@ const ButtonGroup = {
     ...baseProps
   },
   render (h) {
-    const children = this.$slots.default
+    const children = this.$slots.default.filter(e => e.tag)
     const count = children.length
 
     const clones = children.map((node, index) => {

--- a/packages/kiwi-core/src/InputGroup/index.js
+++ b/packages/kiwi-core/src/InputGroup/index.js
@@ -26,7 +26,7 @@ const InputGroup = {
     let pl = null
     let pr = null
     const height = inputSizes[this.size] && inputSizes[this.size]['height']
-    const children = this.$slots.default
+    const children = this.$slots.default.filter(e => e.tag)
     const clones = children
       .map((vnode) => {
         if (vnode.tag.includes(InputLeftElement.name)) {

--- a/packages/kiwi-core/src/Menu/MenuOption.js
+++ b/packages/kiwi-core/src/Menu/MenuOption.js
@@ -218,7 +218,7 @@ const MenuOptionGroup = {
       }
     }
 
-    const children = this.$slots.default
+    const children = this.$slots.default.filter(e => e.tag)
 
     const clonedChildNodes = children.map(vnode => {
       let result

--- a/packages/kiwi-core/src/Popover/index.js
+++ b/packages/kiwi-core/src/Popover/index.js
@@ -304,7 +304,7 @@ const PopoverTrigger = {
   },
   render (h) {
     let clone
-    const children = this.$slots.default
+    const children = this.$slots.default.filter(e => e.tag)
     if (!children) return console.error('[Chakra-ui]: Popover Trigger expects at least one child')
     if (children.length && children.length > 1) return console.error('[Chakra-ui]: Popover Trigger can only have a single child element')
     const cloned = cloneVNode(children[0], h)

--- a/packages/kiwi-core/src/Stack/index.js
+++ b/packages/kiwi-core/src/Stack/index.js
@@ -53,7 +53,7 @@ const Stack = {
       _direction = 'column'
     }
 
-    const children = this.$slots.default
+    const children = this.$slots.default.filter(e => e.tag)
     const stackables = children.map((node, index) => {
       let isLastChild = children.length === index + 1
       let spacingProps = _isInline

--- a/stories/26-Menu.stories.js
+++ b/stories/26-Menu.stories.js
@@ -1,12 +1,12 @@
 import { storiesOf } from '@storybook/vue'
-import { Menu, MenuGroup, MenuButton, MenuList, MenuOptionGroup, MenuItemOption, MenuItem, MenuDivider } from '../packages/kiwi-core/src'
+import { Menu, MenuGroup, MenuButton, MenuList, MenuOptionGroup, MenuItemOption, MenuItem, MenuDivider, Icon } from '../packages/kiwi-core/src'
 
 storiesOf('UI | Menu', module)
   .add('Default Menu', () => ({
-    components: { Menu, MenuGroup, MenuButton, MenuList, MenuItem, MenuDivider },
+    components: { Menu, MenuGroup, MenuButton, MenuList, MenuItem, MenuDivider, Icon },
     template: `
     <Menu>
-      <MenuButton as={Button} rightIcon="chevron-down">
+      <MenuButton as="Button" rightIcon="chevron-down">
         Actions
       </MenuButton>
       <MenuList>
@@ -43,7 +43,7 @@ storiesOf('UI | Menu', module)
     `
   }))
   .add('With letter navigation', () => ({
-    components: { Menu, MenuGroup, MenuButton, MenuList, MenuItem, MenuDivider },
+    components: { Menu, MenuGroup, MenuButton, MenuList, MenuItem, MenuDivider, Icon },
     template: `
     <Menu>
       <MenuButton

--- a/stories/27-Popover.stories.js
+++ b/stories/27-Popover.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue'
-import { Button, Popover, PopoverTrigger, PopoverContent, DarkMode, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter, Box, ButtonGroup, Text } from '../packages/kiwi-core/src'
+import { Avatar, Button, Badge, Popover, PopoverTrigger, PopoverContent, DarkMode, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter, Box, ButtonGroup, Text } from '../packages/kiwi-core/src'
 
 storiesOf('UI | Popover', module)
   .add('Basic Usage', () => ({
@@ -82,7 +82,7 @@ storiesOf('UI | Popover', module)
     `
   }))
   .add('Accessing Internal state', () => ({
-    components: { Button, Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter },
+    components: { Button, Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter, Box },
     template: `
       <Popover
         initialFocusRef="#initRef"
@@ -115,7 +115,7 @@ storiesOf('UI | Popover', module)
     `
   }))
   .add('Customizing the Popover', () => ({
-    components: { Button, Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter },
+    components: { Button, Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter, Box },
     template: `
       <Popover>
         <PopoverTrigger>
@@ -143,13 +143,13 @@ storiesOf('UI | Popover', module)
     `
   }))
   .add('Hover Trigger', () => ({
-    components: { DarkMode, KText: Text, Button, Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter },
+    components: { DarkMode, KText: Text, Button, Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody, PopoverArrow, PopoverCloseButton, PopoverFooter, Box, Avatar, Badge },
     template: `
       <Popover trigger="hover">
         <PopoverTrigger>
-          <Anchor href="#" color="blue.500">
+          <Button color="blue.500">
             Hover to see @swyx profile
-          </Anchor>
+          </Button>
         </PopoverTrigger>
         <DarkMode>
           <PopoverContent border="0" zIndex="4" width="400px" color="white">


### PR DESCRIPTION
## Description
Hey @codebender828  as you  know there was an issue with storybook. It's because of whitespaces. https://vue-loader.vuejs.org/options.html#compileroptions 

But we should be filtering vnodes anyway. 

Fixed Components and Stories:

- Accordion
- Button Group
- Popover
- Menu Option
- Stack
- Breadcrumb
- Avatar Group
- Input Group

I've also fixed some missing imports in stories. All stories work now 🚀

before - after :
![Screenshot 2020-02-19 at 23 06 26](https://user-images.githubusercontent.com/342666/74871465-946d8400-536c-11ea-86fd-3899025a92e7.png)
